### PR TITLE
Bumping version to full release of version 0.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-tools"
-version = "0.0.2a0"
+version = "0.0.2"
 description = "A framework to allow for consistent implementation of tools for the GeneWeaver project."
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"


### PR DESCRIPTION
This change will officially release version 0.0.2 of the geneweaver tools framework.